### PR TITLE
Fix minor bug

### DIFF
--- a/activitywatch/api.py
+++ b/activitywatch/api.py
@@ -7,7 +7,7 @@ from . import utils
 
 
 class ActivityWatchAPI(object):
-	_last_heartbeat = datetime.now()
+	_last_heartbeat = datetime.utcnow()
 	debug = False
 	url = None
 

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def get_project_name(view):
 				break
 	if DEBUG:
 		utils.log("project: {}".format(project))
-	return project
+	return str(project)
 
 
 def get_language(view):


### PR DESCRIPTION
changelog:
- set last_heartbeat default to UTC timezone, because it will return local timezone then causing calculation error on [this line](https://github.com/fahmiamir15/aw-watcher-sublimetext/blob/7739c7bba7e618fdd0ebb600ed7797cd14a25a84/activitywatch/api.py#L31) 
- force project as string datatype, because sometimes it returns dict datatype then causing an error on [this line](https://github.com/fahmiamir15/aw-watcher-sublimetext/blob/7739c7bba7e618fdd0ebb600ed7797cd14a25a84/main.py#L83) 
